### PR TITLE
Fix: forward JSON/urlencoded request bodies on proxied routes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
+# 0.1.2
+
+- Fix proxied requests with a JSON/urlencoded body hanging: the global bodyParser consumed the request stream before http-proxy forwarded it, so PUT/POST bodies never reached the upstream service. Re-stream the parsed body on proxyReq.
+
 # 0.1.1
 
 - Fix slow container startup: exclude node_modules from chown in entrypoint

--- a/components/WebServer/controllers/lib/create.js
+++ b/components/WebServer/controllers/lib/create.js
@@ -21,6 +21,28 @@ async function create(serviceToStart) {
         console.error(err)
       })
 
+      // The WebServer applies bodyParser.json()/urlencoded() globally, which
+      // consumes the request stream. Without re-streaming, proxied requests
+      // carrying a JSON (or urlencoded) body — e.g. PUT — reach the upstream
+      // service with no body and hang. Re-write the parsed body on proxyReq.
+      // Multipart bodies are not parsed by bodyParser, so they stream intact.
+      proxy.on('proxyReq', function (proxyReq, req) {
+        if (!req.body || typeof req.body !== 'object' || Object.keys(req.body).length === 0) {
+          return
+        }
+        const contentType = proxyReq.getHeader('Content-Type') || ''
+        let bodyData
+        if (contentType.includes('application/json')) {
+          bodyData = JSON.stringify(req.body)
+        } else if (contentType.includes('application/x-www-form-urlencoded')) {
+          bodyData = require('querystring').stringify(req.body)
+        }
+        if (bodyData) {
+          proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData))
+          proxyReq.write(bodyData)
+        }
+      })
+
       debug(`Create route ${endpointPath} for service ${serviceToStart.serviceName} with host ${serviceHost}`)
 
       this.express.use(endpointPath, async (req, res, next) => {


### PR DESCRIPTION
## Problem
The WebServer applies `bodyParser.json()` / `bodyParser.urlencoded()` globally (`components/WebServer/index.js`), which consumes the request stream. `http-proxy` (`components/WebServer/controllers/lib/create.js`) then forwards the request with no remaining body, so any proxied request carrying a JSON or urlencoded body (typically PUT/POST) reaches the upstream service with an empty body and hangs until the upstream times out.

Multipart bodies are unaffected (bodyParser does not parse them), which is why file uploads work while JSON-body endpoints hang.

## Impact
Any service behind the gateway that exposes JSON-body endpoints. Surfaced while integrating speaker identification: the `PUT /speaker-identification/collections/{c}/speakers/{id}` upsert (JSON vector body) hung through the gateway but worked when called directly.

## Fix
Add a `proxyReq` handler that re-writes the parsed body (`req.body`) onto the proxied request for JSON and urlencoded content types, setting the correct Content-Length. Multipart and bodyless requests are untouched.

## Test
Verified end to end on the local stack: PUT with a JSON body now returns in ~1s through the gateway (previously timed out), and the speaker-identification enrollment/transcription flow works through the gateway.